### PR TITLE
Fix channel ID parsing from user input

### DIFF
--- a/digestbot/core/ui_processor/common.py
+++ b/digestbot/core/ui_processor/common.py
@@ -1,3 +1,5 @@
+import re
+
 from dataclasses import dataclass
 from typing import Optional
 
@@ -14,7 +16,11 @@ class UserRequest:
 def parse_channel_id(channel: str) -> Optional[str]:
     if not channel:
         return None
-    split = channel.strip("<>").split("|")
-    if len(split) == 2:
-        return split[0].lstrip("#")
-    return None
+
+    # example: <#C6JKNA63|#channel_name>
+    channel_id_regexp = r"<#(?P<id>[A-Z\d]+)\|.+>"
+
+    match = re.fullmatch(pattern=channel_id_regexp, string=channel)
+    if not match:
+        return None
+    return match.group("id")

--- a/digestbot/core/ui_processor/top/top_command.py
+++ b/digestbot/core/ui_processor/top/top_command.py
@@ -11,6 +11,7 @@ from digestbot.command_parser.argument import (
 )
 from digestbot.command_parser.command import CommandBuilder
 from digestbot.core.common.Enums import SortingType
+from digestbot.core.ui_processor.common import parse_channel_id
 
 top_arguments = (
     IntArgument("N", default=5),
@@ -33,17 +34,18 @@ class TopCommandArgs:
     category_name: Optional[str] = None
 
     @staticmethod
-    def _parse_channel(channel: Optional[str]) -> Dict[str, str]:
-        if not channel:
+    def _parse_channel(source_name: Optional[str]) -> Dict[str, str]:
+        if not source_name:
             return {}
-        split = channel.strip("<>").split("|")
-        if len(split) == 1:
-            return {"category_name": split[0]}
-        if len(split) == 2:
-            return {"channel_id": split[0].lstrip("#")}
-        raise ValueError(
-            f"Channel Id format is not recognized (split result is {split}). Possible Slack API change"
-        )
+
+        channel_uid = parse_channel_id(channel=source_name)
+
+        # Either ID successfully parsed...
+        if channel_uid:
+            return {"channel_id": channel_uid}
+
+        # ...or it is category name. No other ways.
+        return {"category_name": source_name}
 
     def is_all_channels_requested(self) -> bool:
         return self.category_name is None and self.channel_id is None


### PR DESCRIPTION
Fix erroneous channel ID parsing, that allowed to input channels like "<_#_meetings" and parse it to <_CHANNEL_ID instead of just CHANNEL_ID. Moreover, some commands could possibly raise unhandled exception during parsing processing.